### PR TITLE
Fixing application crash when changing songs rapidly

### DIFF
--- a/app/src/main/java/com/devs/musicplayer/PlayerActivity.java
+++ b/app/src/main/java/com/devs/musicplayer/PlayerActivity.java
@@ -156,6 +156,9 @@ public class PlayerActivity extends AppCompatActivity {
                             } catch (InterruptedException e) {
                                 e.printStackTrace();
                             }
+                             catch (IllegalStateException e){
+                                e.printStackTrace();
+                            }
                         }
                     }
                 })


### PR DESCRIPTION
When changing songs more than two times app was crashing , and IllegalStateException was thrown, so caught it in **PlayerActivity.java**
...
..                             
catch (IllegalStateException e){
                                e.printStackTrace();
                            }
..
..
After catching above exception, thread runs successfully and songs are changing without crash